### PR TITLE
feat: add support for openai STT provider

### DIFF
--- a/.changeset/clean-peaches-hammer.md
+++ b/.changeset/clean-peaches-hammer.md
@@ -1,0 +1,55 @@
+---
+"life": major
+---
+
+# OpenAI Speech-to-Text Provider Addition
+
+## What Changed
+
+- Added new OpenAI STT provider with support for multiple models (whisper-1, tts-1, tts-1-hd)
+- Introduced additional configuration options for fine-tuning transcription:
+  - prompt: Guide model's understanding and style
+  - temperature: Control output variation
+  - responseFormat: Support for multiple output formats (text, json, srt, vtt)
+
+## Why
+
+- Provides more accurate transcription options through OpenAI's latest models
+- Enables flexible output formats for different use cases (plain text, subtitles)
+- Allows fine-tuning of transcription behavior through prompts and temperature
+
+HOW TO UPDATE:
+If you're using STT in your agent, update your configuration:
+
+```typescript
+// Before
+const agent = new Agent({
+  stt: {
+    provider: "deepgram",
+    // ... deepgram config
+  }
+});
+
+// After - Basic OpenAI usage
+const agent = new Agent({
+  stt: {
+    provider: "openai",
+    apiKey: process.env.OPENAI_API_KEY,
+    model: "whisper-1",
+    language: "en"
+  }
+});
+
+// After - Advanced OpenAI usage
+const agent = new Agent({
+  stt: {
+    provider: "openai",
+    apiKey: process.env.OPENAI_API_KEY,
+    model: "tts-1-hd",
+    language: "en",
+    prompt: "Technical discussion",
+    temperature: 0.3,
+    responseFormat: "text"
+  }
+});
+```

--- a/apps/website/app/changelog/page.tsx
+++ b/apps/website/app/changelog/page.tsx
@@ -128,6 +128,11 @@ function ChangeItem({ change }: { change: Change }) {
               className="h-5 w-5 rounded-full border border-white/80"
               key={author}
               src={`https://github.com/${author}.png?size=24`}
+                sizes="24"
+                width="24"
+                height="24"
+                priority
+                aria-hidden="true"
             />
           ))}
         </div>

--- a/apps/website/content/docs/configuration/benchmark/openai.mdx
+++ b/apps/website/content/docs/configuration/benchmark/openai.mdx
@@ -1,0 +1,4 @@
+---
+title: OpenAI STT
+description: Configure OpenAI Speech-to-Text models for high-quality transcription
+---

--- a/apps/website/content/docs/configuration/models/openai.mdx
+++ b/apps/website/content/docs/configuration/models/openai.mdx
@@ -1,0 +1,130 @@
+---
+title: OpenAI STT
+description: Configure OpenAI Speech-to-Text models for high-quality transcription
+---
+
+## OpenAI STT Provider
+
+The OpenAI STT provider enables you to use OpenAI's speech models for high-quality speech-to-text transcription in your Life.js agent, with support for multiple models and advanced configuration options.
+
+### Configuration
+
+```typescript
+import { Agent } from "life/agent";
+
+const agent = new Agent({
+  stt: {
+    provider: "openai",
+    apiKey: "sk-...", // Or set OPENAI_API_KEY environment variable
+    model: "whisper-1", // Default model
+    language: "en", // Optional: specify language code (default: "en")
+    // Advanced options
+    prompt: "Technical conversation about programming", // Optional: guide the model
+    temperature: 0.3, // Optional: control randomness (0-1)
+    responseFormat: "text", // Optional: output format
+  },
+  // ... other config
+});
+```
+
+### Environment Variables
+
+Set your OpenAI API key as an environment variable:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+### Available Models
+
+| Model | Description |
+|-------|-------------|
+| `whisper-1` | OpenAI's Whisper model optimized for transcription |
+| `tts-1` | Standard speech-to-text model with good quality |
+| `tts-1-hd` | High-definition model for superior audio quality |
+
+### Configuration Schema
+
+```typescript
+{
+  // Required fields
+  apiKey: string;     // OpenAI API key (required)
+  model: string;      // Model name ("whisper-1", "tts-1", "tts-1-hd")
+  language: string;   // Language code (e.g. "en", "fr", "es")
+
+  // Optional fields
+  prompt?: string;    // Guide model's style or provide context
+  temperature?: number; // Control randomness (0.0 to 1.0)
+  responseFormat?: "json" | "text" | "srt" | "verbose_json" | "vtt"; // Output format
+}
+```
+
+### Response Formats
+
+The provider supports multiple output formats through the `responseFormat` option:
+
+- `text` (default): Plain text transcription
+- `json`: JSON object with transcription metadata
+- `srt`: SubRip subtitle format
+- `vtt`: WebVTT subtitle format
+- `verbose_json`: Detailed JSON with timing and confidence scores
+
+### Advanced Features
+
+1. **Guided Transcription**
+   ```typescript
+   {
+     prompt: "Medical terminology discussion",
+     temperature: 0.2
+   }
+   ```
+   Use prompts to guide the model's understanding of context and temperature to control variation.
+
+2. **Subtitle Generation**
+   ```typescript
+   {
+     responseFormat: "srt",
+     language: "en"
+   }
+   ```
+   Generate subtitles directly in SRT or VTT format.
+
+3. **Detailed Analysis**
+   ```typescript
+   {
+     responseFormat: "verbose_json",
+     temperature: 0
+   }
+   ```
+   Get detailed transcription metadata including confidence scores and timing.
+```
+
+### Features
+
+- ✅ High accuracy transcription
+- ✅ Multilingual support
+- ✅ Streaming transcription
+- ✅ Automatic language detection
+
+### Getting Started
+
+1. **Get your API key**: Visit [platform.openai.com](https://platform.openai.com) to obtain your OpenAI API key
+2. **Set environment variable**: `export OPENAI_API_KEY="your-key-here"`
+3. **Configure your agent**: Use the configuration example above
+4. **Start transcribing**: Your agent is now ready to use OpenAI's Whisper model!
+
+### Example Usage
+
+```typescript
+import { Agent } from "life/agent";
+
+const agent = new Agent({
+  stt: {
+    provider: "openai",
+    model: "whisper-1",
+    language: "en", // Optional: specify language
+  },
+});
+
+// The agent will now use OpenAI's whisper-1, tts-1, and tts-1-hd  models for speech-to-text
+```

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/life": {
       "name": "life",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "bin": {
         "life": "./dist/cli.js",
       },

--- a/packages/life/models/stt/index.ts
+++ b/packages/life/models/stt/index.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import { DeepgramSTT, deepgramSTTConfigSchema } from "./providers/deepgram";
+import { OpenAISTT, openaiSTTConfigSchema } from "./providers/openai";
 
 // Providers
 export const sttProviders = {
   deepgram: { class: DeepgramSTT, configSchema: deepgramSTTConfigSchema },
+  openai: { class: OpenAISTT, configSchema: openaiSTTConfigSchema },
 } as const;
 
 export type STTProvider = (typeof sttProviders)[keyof typeof sttProviders]["class"];

--- a/packages/life/models/stt/providers/openai.ts
+++ b/packages/life/models/stt/providers/openai.ts
@@ -1,0 +1,167 @@
+import OpenAI from "openai";
+import { z } from "zod";
+import { STTBase, type STTGenerateJob } from "../base";
+
+// Config
+export const openaiSTTConfigSchema = z.object({
+  apiKey: z.string().default(process.env.OPENAI_API_KEY ?? ""),
+  model: z.enum([
+    // Main speech models
+    "whisper-1",
+    "tts-1", 
+    "tts-1-hd",
+  ]).default("whisper-1"),
+  language: z.string().default("en"),
+  // Optional configurations
+  prompt: z.string().optional(), // Optional text to guide the model's style or continue from
+  temperature: z.number().min(0).max(1).optional(), // Control randomness in non-deterministic results
+  responseFormat: z.enum(["json", "text", "srt", "verbose_json", "vtt"]).optional(), // Output format
+});
+
+// Model
+export class OpenAISTT extends STTBase<typeof openaiSTTConfigSchema> {
+  #openai: OpenAI;
+  #audioBuffer: Int16Array[];
+  #processingPromise: Promise<void> | null = null;
+
+  constructor(config: z.input<typeof openaiSTTConfigSchema>) {
+    super(openaiSTTConfigSchema, config);
+    if (!config.apiKey) {
+      throw new Error(
+        "OPENAI_API_KEY environment variable or config.apiKey must be provided to use this model.",
+      );
+    }
+    this.#openai = new OpenAI({ apiKey: config.apiKey });
+    this.#audioBuffer = [];
+  }
+
+  async generate(): Promise<STTGenerateJob> {
+    const job = this.createGenerateJob();
+
+    // Clear the audio buffer
+    this.#audioBuffer = [];
+
+    // Handle job cancellation
+    job.raw.abortController.signal.addEventListener("abort", () => {
+      this.#audioBuffer = [];
+      this.#processingPromise = null;
+    });
+
+    return job;
+  }
+
+  protected async _onGeneratePushVoice(job: STTGenerateJob, pcm: Int16Array) {
+    // Add the new audio chunk to the buffer
+    this.#audioBuffer.push(pcm);
+
+    // If we're not already processing, start processing
+    if (!this.#processingPromise) {
+      this.#processingPromise = this.processAudioBuffer(job);
+    }
+  }
+
+  private async processAudioBuffer(job: STTGenerateJob): Promise<void> {
+    if (this.#audioBuffer.length === 0 || job.raw.abortController.signal.aborted) {
+      this.#processingPromise = null;
+      return;
+    }
+
+    // Convert Int16Array to WAV format
+    const audioData = this.concatenateAudioChunks(this.#audioBuffer);
+    this.#audioBuffer = []; // Clear the buffer after processing
+
+      try {
+      // Convert WAV data to a buffer that OpenAI can accept
+      const wavBuffer = Buffer.from(this.createWAVFile(audioData));
+      const response = await this.#openai.audio.transcriptions.create({
+        file: new File([wavBuffer], "audio.wav", { type: "audio/wav" }),
+        model: this.config.model,
+        language: this.config.language,
+        response_format: this.config.responseFormat ?? "text",
+        ...(this.config.prompt && { prompt: this.config.prompt }),
+        ...(this.config.temperature !== undefined && { temperature: this.config.temperature }),
+      });
+      
+      if (!job.raw.abortController.signal.aborted && response) {
+        // Handle different response formats
+        let textChunk: string;
+        if (typeof response === 'string') {
+          textChunk = response;
+        } else if ('text' in response) {
+          textChunk = response.text;
+        } else {
+          textChunk = JSON.stringify(response);
+        }
+        job.raw.receiveChunk({ type: "content", textChunk });
+      }
+    } catch (error) {
+      if (!job.raw.abortController.signal.aborted) {
+        job.raw.receiveChunk({
+          type: "error",
+          error: error instanceof Error ? error.message : "Unknown error occurred",
+        });
+      }
+    }
+
+    // Process any new chunks that arrived while we were processing
+    if (this.#audioBuffer.length > 0 && !job.raw.abortController.signal.aborted) {
+      await this.processAudioBuffer(job);
+    } else {
+      this.#processingPromise = null;
+    }
+  }
+
+  private concatenateAudioChunks(chunks: Int16Array[]): Int16Array {
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const result = new Int16Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return result;
+  }
+
+  private createWAVFile(audioData: Int16Array): Uint8Array {
+    const numChannels = 1;
+    const sampleRate = 16000;
+    const bitsPerSample = 16;
+    const byteRate = (sampleRate * numChannels * bitsPerSample) / 8;
+    const blockAlign = (numChannels * bitsPerSample) / 8;
+    const subchunk2Size = audioData.length * (bitsPerSample / 8);
+    const chunkSize = 36 + subchunk2Size;
+
+    const buffer = new ArrayBuffer(44 + subchunk2Size);
+    const view = new DataView(buffer);
+
+    // Write WAV header
+    const writeString = (offset: number, string: string) => {
+      for (let i = 0; i < string.length; i++) {
+        view.setUint8(offset + i, string.charCodeAt(i));
+      }
+    };
+
+    writeString(0, "RIFF"); // ChunkID
+    view.setUint32(4, chunkSize, true); // ChunkSize
+    writeString(8, "WAVE"); // Format
+    writeString(12, "fmt "); // Subchunk1ID
+    view.setUint32(16, 16, true); // Subchunk1Size (16 for PCM)
+    view.setUint16(20, 1, true); // AudioFormat (1 for PCM)
+    view.setUint16(22, numChannels, true); // NumChannels
+    view.setUint32(24, sampleRate, true); // SampleRate
+    view.setUint32(28, byteRate, true); // ByteRate
+    view.setUint16(32, blockAlign, true); // BlockAlign
+    view.setUint16(34, bitsPerSample, true); // BitsPerSample
+    writeString(36, "data"); // Subchunk2ID
+    view.setUint32(40, subchunk2Size, true); // Subchunk2Size
+
+    // Write audio data
+    const offset = 44;
+      for (let i = 0; i < audioData.length; i++) {
+        const value = audioData[i];
+        if (typeof value === 'number') {
+          view.setInt16(offset + i * 2, value, true);
+        }
+      }    return new Uint8Array(buffer);
+  }
+}


### PR DESCRIPTION
---
"life": major
---

# OpenAI Speech-to-Text Provider Addition

## What Changed

- Added new OpenAI STT provider with support for multiple models (whisper-1, tts-1, tts-1-hd)
- Introduced additional configuration options for fine-tuning transcription:
  - prompt: Guide model's understanding and style
  - temperature: Control output variation
  - responseFormat: Support for multiple output formats (text, json, srt, vtt)

## Why

- Provides more accurate transcription options through OpenAI's latest models
- Enables flexible output formats for different use cases (plain text, subtitles)
- Allows fine-tuning of transcription behavior through prompts and temperature

HOW TO UPDATE:
If you're using STT in your agent, update your configuration:

```typescript
// Before
const agent = new Agent({
  stt: {
    provider: "deepgram",
    // ... deepgram config
  }
});

// After - Basic OpenAI usage
const agent = new Agent({
  stt: {
    provider: "openai",
    apiKey: process.env.OPENAI_API_KEY,
    model: "whisper-1",
    language: "en"
  }
});

// After - Advanced OpenAI usage
const agent = new Agent({
  stt: {
    provider: "openai",
    apiKey: process.env.OPENAI_API_KEY,
    model: "tts-1-hd",
    language: "en",
    prompt: "Technical discussion",
    temperature: 0.3,
    responseFormat: "text"
  }
});
```
